### PR TITLE
Add imagemagick to CI dependencies

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,8 @@ jobs:
         with:
           lfs: true
 
+      - run: sudo apt-get update && sudo apt-get install -y imagemagick
+
       - uses: astral-sh/setup-uv@v5
 
       - run: uv sync


### PR DESCRIPTION
Lektor requires imagemagick for image processing during build.